### PR TITLE
chore: retarget SDK packages for optimal compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes documented here. Format: [Keep a Changelog](https://keepacha
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-03-02
+
+### Changed
+
+- **HVO.ZWOOptical.ASISDK 0.0.4** — Retargeted from netstandard2.1 to **netstandard2.0** for maximum compatibility (including .NET Framework 4.8.1). Added `Math.Clamp` polyfill.
+- **HVO.Astronomy.CFITSIO 1.0.4** — Retargeted from net9.0 to **net10.0** to leverage latest `[LibraryImport]` source-generated P/Invoke improvements
+- **HVO.Astronomy.CFITSIO.NativeAssets 1.0.4** — Retargeted from net9.0 to **net10.0** (aligned with CFITSIO)
+- **HVO.Iot.Devices 1.1.0** — Retargeted from net9.0 to **net8.0** (minimum required by `System.Device.Gpio`/`Iot.Device.Bindings` packages). Updated `System.Device.Gpio` and `Iot.Device.Bindings` from 4.0.1 to 4.1.0.
+
 ## [1.1.0] - 2026-03-02
 
 ### Added

--- a/src/HVO.Astronomy.CFITSIO.NativeAssets/HVO.Astronomy.CFITSIO.NativeAssets.csproj
+++ b/src/HVO.Astronomy.CFITSIO.NativeAssets/HVO.Astronomy.CFITSIO.NativeAssets.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <SignAssembly>false</SignAssembly>
 
     <!-- No managed code - this is just a native assets package -->
@@ -11,7 +11,7 @@
     <IncludeSymbols>false</IncludeSymbols>
 
     <PackageId>HVO.Astronomy.CFITSIO.NativeAssets</PackageId>
-    <Version>1.0.3</Version>
+    <Version>1.0.4</Version>
     <Description>Native CFITSIO binaries for multiple platforms (macOS/Linux/Windows, multi-RID). This package contains only native assets and is referenced by HVO.Astronomy.CFITSIO.</Description>
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
     <PackageTags>Astronomy,FITS,Native</PackageTags>

--- a/src/HVO.Astronomy.CFITSIO/HVO.Astronomy.CFITSIO.csproj
+++ b/src/HVO.Astronomy.CFITSIO/HVO.Astronomy.CFITSIO.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 
@@ -11,7 +11,7 @@
     <RootNamespace>HVO.Astronomy.CFITSIO</RootNamespace>
     <AssemblyName>HVO.Astronomy.CFITSIO</AssemblyName>
     <PackageId>HVO.Astronomy.CFITSIO</PackageId>
-    <Version>1.0.3</Version>
+    <Version>1.0.4</Version>
     <Description>CFITSIO native binaries for P/Invoke (macOS/Linux/Windows, multi-RID).</Description>
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
     <PackageTags>Astronomy,FITS</PackageTags>

--- a/src/HVO.Iot.Devices/HVO.Iot.Devices.csproj
+++ b/src/HVO.Iot.Devices/HVO.Iot.Devices.csproj
@@ -1,19 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>true</IsPackable>
     <PackageId>HVO.Iot.Devices</PackageId>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <Description>IoT device abstractions and implementations for GPIO, I2C, and Sequent Microsystems HATs.</Description>
     <PackageTags>iot;gpio;i2c;raspberry-pi;sequent;hvo</PackageTags>
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="4.0.1" />
-    <PackageReference Include="Iot.Device.Bindings" Version="4.0.1" />
+    <PackageReference Include="System.Device.Gpio" Version="4.1.0" />
+    <PackageReference Include="Iot.Device.Bindings" Version="4.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.10" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.10" />
   </ItemGroup>

--- a/src/HVO.ZWOOptical.ASISDK/ASICamera2.cs
+++ b/src/HVO.ZWOOptical.ASISDK/ASICamera2.cs
@@ -11,6 +11,12 @@ namespace HVO.ZWOOptical.ASISDK
     {
         private const string ASILIBRARY = "ASICamera2";
 
+        /// <summary>
+        /// Polyfill for Math.Clamp (not available in .NET Standard 2.0).
+        /// </summary>
+        private static long Clamp(long value, long min, long max)
+            => value < min ? min : (value > max ? max : value);
+
         // Determines if the native SDK uses 64-bit C 'long' (Linux/macOS) vs 32-bit (Windows)
         public static bool Use64Structs { get; } =
             System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ||
@@ -52,8 +58,8 @@ namespace HVO.ZWOOptical.ASISDK
             var cam32 = new ASI_CAMERA_INFO_32
             {
                 CameraID = cam64.CameraID,
-                MaxHeight = (int)Math.Clamp(cam64.MaxHeight, int.MinValue, int.MaxValue),
-                MaxWidth = (int)Math.Clamp(cam64.MaxWidth, int.MinValue, int.MaxValue),
+                MaxHeight = (int)Clamp(cam64.MaxHeight, int.MinValue, int.MaxValue),
+                MaxWidth = (int)Clamp(cam64.MaxWidth, int.MinValue, int.MaxValue),
                 IsColorCam = cam64.IsColorCam,
                 BayerPattern = cam64.BayerPattern,
                 SupportedBins = cam64.SupportedBins,
@@ -243,9 +249,9 @@ namespace HVO.ZWOOptical.ASISDK
             // Down-convert long fields to int with clamping (most control ranges fit in int)
             var result = new ASI_CONTROL_CAPS_32
             {
-                MaxValue = (int)Math.Clamp(caps64.MaxValue, int.MinValue, int.MaxValue),
-                MinValue = (int)Math.Clamp(caps64.MinValue, int.MinValue, int.MaxValue),
-                DefaultValue = (int)Math.Clamp(caps64.DefaultValue, int.MinValue, int.MaxValue),
+                MaxValue = (int)Clamp(caps64.MaxValue, int.MinValue, int.MaxValue),
+                MinValue = (int)Clamp(caps64.MinValue, int.MinValue, int.MaxValue),
+                DefaultValue = (int)Clamp(caps64.DefaultValue, int.MinValue, int.MaxValue),
                 IsAutoSupported = caps64.IsAutoSupported,
                 IsWritable = caps64.IsWritable,
                 ControlType = caps64.ControlType,
@@ -282,7 +288,7 @@ namespace HVO.ZWOOptical.ASISDK
                 return GetControlValue32(cameraId, controlType, out isAuto);
             }
             var v64 = GetControlValue64(cameraId, controlType, out isAuto);
-            return (int)Math.Clamp(v64, int.MinValue, int.MaxValue);
+            return (int)Clamp(v64, int.MinValue, int.MaxValue);
         }
 
         public static void SetControlValueCompat(int cameraId, ASI_CONTROL_TYPE controlType, int value, bool auto)
@@ -531,8 +537,8 @@ namespace HVO.ZWOOptical.ASISDK
             var converted = new ASI_CAMERA_INFO_32
             {
                 CameraID = info64.CameraID,
-                MaxHeight = (int)Math.Clamp(info64.MaxHeight, int.MinValue, int.MaxValue),
-                MaxWidth = (int)Math.Clamp(info64.MaxWidth, int.MinValue, int.MaxValue),
+                MaxHeight = (int)Clamp(info64.MaxHeight, int.MinValue, int.MaxValue),
+                MaxWidth = (int)Clamp(info64.MaxWidth, int.MinValue, int.MaxValue),
                 IsColorCam = info64.IsColorCam,
                 BayerPattern = info64.BayerPattern,
                 SupportedBins = info64.SupportedBins,

--- a/src/HVO.ZWOOptical.ASISDK/HVO.ZWOOptical.ASISDK.csproj
+++ b/src/HVO.ZWOOptical.ASISDK/HVO.ZWOOptical.ASISDK.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>10.0</LangVersion>
     <SignAssembly>false</SignAssembly>
     <IsPackable>true</IsPackable>
@@ -11,7 +11,7 @@
     <RootNamespace>HVO.ZWOOptical.ASISDK</RootNamespace>
     <AssemblyName>HVO.ZWOOptical.ASISDK</AssemblyName>
     <PackageId>HVO.ZWOOptical.ASISDK</PackageId>
-    <Version>0.0.3</Version>
+    <Version>0.0.4</Version>
     <Description>ZWO ASI Camera SDK P/Invoke wrapper for .NET (macOS/Linux, multi-RID).</Description>
     <PackageLicenseExpression></PackageLicenseExpression>
     <PackageLicenseFile>license.txt</PackageLicenseFile>

--- a/tests/HVO.Astronomy.CFITSIO.Tests/HVO.Astronomy.CFITSIO.Tests.csproj
+++ b/tests/HVO.Astronomy.CFITSIO.Tests/HVO.Astronomy.CFITSIO.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
## Summary

Retarget SDK packages for optimal compatibility, choosing the best TFM for each package based on its API requirements.

## Changes

| Package | Before | After | Version | Rationale |
|---------|--------|-------|---------|-----------|
| **HVO.ZWOOptical.ASISDK** | netstandard2.1 | **netstandard2.0** | 0.0.3 → 0.0.4 | Pure P/Invoke, zero deps — max compatibility (incl. .NET Framework 4.8.1). Added `Math.Clamp` polyfill. |
| **HVO.Iot.Devices** | net9.0 | **net8.0** | 1.0.0 → 1.1.0 | `System.Device.Gpio` and `Iot.Device.Bindings` only ship net8.0 libs — no benefit going higher. Updated both from 4.0.1 → 4.1.0. |
| **HVO.Astronomy.CFITSIO** | net9.0 | **net10.0** | 1.0.3 → 1.0.4 | Uses `[LibraryImport]` source-gen P/Invoke (net7.0+ requirement) — net10.0 gets latest marshalling improvements. |
| **HVO.Astronomy.CFITSIO.NativeAssets** | net9.0 | **net10.0** | 1.0.3 → 1.0.4 | Aligned with CFITSIO. |

## Why not .NET Standard for CFITSIO and Iot.Devices?

- **CFITSIO**: Uses `[LibraryImport]` (30+ source-gen P/Invoke declarations), `NativeLibrary.SetDllImportResolver`, `[ModuleInitializer]`, `nuint` — all require net5.0+. Rewriting to `[DllImport]` would lose performance and add complexity.
- **Iot.Devices**: `System.Device.Gpio` and `Iot.Device.Bindings` packages only publish net8.0 libs. No netstandard path exists.

## Verification

- Build: 0 errors, 0 warnings
- Tests: 297 passed, 8 skipped (CFITSIO native binary tests), 0 failed
