### PR TITLE
fix: add .dotnet/tools to PATH and clean stale obj before restore

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -70,10 +70,16 @@ fi
 # HVO.SDK-specific setup
 # ─────────────────────────────────────────────────────────────────────
 
+# Ensure .NET tools are on PATH
+export PATH="$PATH:/home/vscode/.dotnet/tools"
+grep -qF '.dotnet/tools' /home/vscode/.zshrc 2>/dev/null || \
+	echo 'export PATH="$PATH:/home/vscode/.dotnet/tools"' >> /home/vscode/.zshrc
+
 # Install global .NET tools
 dotnet tool install --global dotnet-reportgenerator-globaltool 2>/dev/null || true
 
-# Restore NuGet packages
+# Clean stale obj dirs that can cause restore conflicts, then restore
+find /workspaces/HVO.SDK -name 'project.assets.json' -delete 2>/dev/null || true
 if ! dotnet restore; then
 	echo "Error: dotnet restore failed. See output above."
 	exit 1


### PR DESCRIPTION
Fixes two issues from the initial devcontainer rebuild:

1. **`.dotnet/tools` not on PATH** — `reportgenerator` installs but isn't usable. Now exported immediately and persisted in `.zshrc`.
2. **Stale `project.assets.json`** — previous build artifacts cause `dotnet restore` to fail with "file already exists". Now cleaned before restore.